### PR TITLE
Delete shoulda matchers from Gemfile

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -64,7 +64,6 @@ group :test do
   gem 'guard-rspec'
   gem 'launchy'
   gem 'rspec-rails'
-  gem 'shoulda-matchers'
   gem 'webdrivers'
 end
 

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -248,8 +248,6 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     shellany (0.0.1)
-    shoulda-matchers (4.5.1)
-      activesupport (>= 4.2.0)
     spring (2.1.1)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
@@ -313,7 +311,6 @@ DEPENDENCIES
   sass-rails (>= 6)
   securerandom
   selenium-webdriver
-  shoulda-matchers
   spring
   turbolinks (~> 5)
   tzinfo-data


### PR DESCRIPTION
In this section, I deleted shoulda matchers from the gemfile because it was not being used.