### PR TITLE
Improve RSpec CI Performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
       - name: Install library for postgres
         run: sudo apt-get install libpq-dev
       - name: Install ruby
@@ -52,7 +58,9 @@ jobs:
         with:
           ruby-version: "2.7"
       - name: Install gems
-        run: bundle install
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
       - name: Setup Database
         run: |
           cp config/database.yml.github-actions config/database.yml


### PR DESCRIPTION
Before this PR, it took over 2 minutes to run continuous integration because the bundle install wasn't cached. Now hopefully the gems will be cached and speed up RSpec.

## Before
![image](https://user-images.githubusercontent.com/60662264/115976377-55affc80-a522-11eb-888d-d7d404b38c93.png)

## After
![image](https://user-images.githubusercontent.com/60662264/115976380-5f396480-a522-11eb-9a33-7920e14d98cb.png)

 