### PR TITLE
Increase sleep time because of rate limit

### DIFF
--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -99,7 +99,7 @@ unless File.exist?('api-responses-resy-responses.json')
 
     raise 'did not work' unless response.status == 200
 
-    sleep(1)
+    sleep(2)
     restaurants_array += parsed_response['results']['venues']
   end
 


### PR DESCRIPTION
Change sleep time from 1 second to 2 seconds to ensure we don't hit rate limit for Resy API.